### PR TITLE
Add manual reload templates

### DIFF
--- a/renders.go
+++ b/renders.go
@@ -204,6 +204,12 @@ func (r *Renderer) RenderBytes(name string, binding ...interface{}) ([]byte, err
 	return r.renders.RenderBytes(name, binding...)
 }
 
+// ManualReloadTemplates 手动重新加载模版信息
+func (r *Renderer) ManualReloadTemplates() (err error) {
+	r.renders.templates, err = compile(r.renders.Options)
+	return err
+}
+
 func (r *Renderer) StatusRender(status int, name string, bindings ...interface{}) error {
 	var binding interface{}
 	if len(bindings) > 0 {


### PR DESCRIPTION
模版信息在运行时执行完成，后期生产环境中需要更新模版时用增加的ManualReloadTemplates方法进行重新加载，不用重启。